### PR TITLE
Refactor workspace handling, task ordering, and TransformedStage data type

### DIFF
--- a/pkg/buildpipeline/pipeline_test.go
+++ b/pkg/buildpipeline/pipeline_test.go
@@ -43,15 +43,15 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					tb.PipelineTaskInputResource("workspace", "common-workspace"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource")),
 				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-a-working-stage-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace")),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-a-working-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
 				)),
 			},
@@ -90,23 +90,23 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
 						tb.From("somepipeline-build-somebuild-stage-a-working-stage-abcd"))),
 				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-a-working-stage-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace")),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-a-working-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-another-stage-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-another-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("again")),
 				)),
 			},
@@ -150,23 +150,23 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
 						tb.From("somepipeline-build-somebuild-stage-a-working-stage-abcd"))),
 				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-a-working-stage-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace")),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-a-working-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-another-stage-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-another-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("again")),
 				)),
 			},
@@ -236,39 +236,39 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.From("somepipeline-build-somebuild-stage-a-working-stage-abcd",
 							"somepipeline-build-somebuild-stage-another-stage-abcd"))),
 				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-first-stage-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace")),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-first-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("first")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-a-working-stage-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-a-working-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-another-stage-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-another-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("again")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-last-stage-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-last-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("last")),
 				)),
 			},
@@ -355,47 +355,47 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 						tb.From("somepipeline-build-somebuild-stage-a-working-stage-abcd",
 							"somepipeline-build-somebuild-stage-some-other-stage-abcd"))),
 				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-first-stage-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace")),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-first-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("first")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-a-working-stage-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-a-working-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-another-stage-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-another-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("again")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-some-other-stage-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-some-other-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("otherwise")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-last-stage-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-last-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("last")),
 				)),
 			},
@@ -462,39 +462,39 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
 						tb.From("somepipeline-build-somebuild-stage-stage3-abcd"))),
 				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-stage1-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace")),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-stage1-step-0-abcd", "some-image", tb.Command("ls")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-stage2-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-stage2-step-0-abcd", "some-image", tb.Command("ls")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-stage3-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-stage3-step-0-abcd", "some-image", tb.Command("ls")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-stage4-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-stage4-step-0-abcd", "some-image", tb.Command("ls")),
 				)),
 			},
@@ -527,15 +527,15 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					tb.PipelineTaskInputResource("workspace", "common-workspace"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource")),
 				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-a-stage-with-environmen-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace")),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-a-stage-with-environment-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("hello", "${SOME_OTHER_VAR}"),
 						// TODO: Ordering doesn't seem to be deterministic.
 						tb.EnvVar("SOME_VAR", "A value for the env var"), tb.EnvVar("SOME_OTHER_VAR", "A value for the other env var")),
@@ -687,15 +687,15 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					tb.PipelineTaskInputResource("workspace", "common-workspace"),
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource")),
 				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-a-working-stage-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace")),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-a-working-stage-step-0-abcd", "some-other-image", tb.Command("echo"), tb.Args("hello", "world")),
 					tb.Step("stage-a-working-stage-step-1-abcd", "some-image", tb.Command("echo"), tb.Args("goodbye")),
 				)),
@@ -735,23 +735,23 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
 						tb.From("somepipeline-build-somebuild-stage-a-abcd"))),
 				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-a-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
 							tb.ResourceTargetPath("workspace")),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-a-step-0-abcd", "some-image", tb.Command("ls")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-wh-this-is-cool-abcd", "somenamespace", tb.TaskSpec(
 					tb.TaskInputs(
 						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
-						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeImage)),
 					tb.Step("stage-wh-this-is-cool-step-0-abcd", "some-image", tb.Command("ls")),
 				)),
 			},

--- a/pkg/buildpipeline/pipeline_test.go
+++ b/pkg/buildpipeline/pipeline_test.go
@@ -12,6 +12,10 @@ import (
 // TODO: Write a builder for generating the expected objects. Because
 // as this is now, there are way too many lines here.
 func TestParseJenkinsfileYaml(t *testing.T) {
+	// Needed to take address of strings since workspace is *string. Is there a better way to handle optional values?
+	defaultWorkspace := "default"
+	customWorkspace := "custom"
+
 	tests := []struct {
 		name             string
 		expected         *Jenkinsfile
@@ -36,13 +40,18 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 			},
 			pipeline: tb.Pipeline("somepipeline-build-somebuild-abcd", "somenamespace", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-build-somebuild-stage-a-working-stage-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace")),
-				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit))),
+					tb.PipelineTaskInputResource("workspace", "common-workspace"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-a-working-stage-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
-						tb.ResourceTargetPath("workspace"))),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-a-working-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
 				)),
 			},
@@ -73,20 +82,31 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 			},
 			pipeline: tb.Pipeline("somepipeline-build-somebuild-abcd", "somenamespace", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-build-somebuild-stage-a-working-stage-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace")),
+					tb.PipelineTaskInputResource("workspace", "common-workspace"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource")),
 				tb.PipelineTask("another-stage", "somepipeline-build-somebuild-stage-another-stage-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace", tb.From("somepipeline-build-somebuild-stage-a-working-stage-abcd"))),
-				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit))),
+					tb.PipelineTaskInputResource("workspace", "common-workspace",
+						tb.From("somepipeline-build-somebuild-stage-a-working-stage-abcd")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("somepipeline-build-somebuild-stage-a-working-stage-abcd"))),
+				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-a-working-stage-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
-						tb.ResourceTargetPath("workspace"))),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-a-working-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-another-stage-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-another-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("again")),
 				)),
 			},
@@ -122,20 +142,31 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 			},
 			pipeline: tb.Pipeline("somepipeline-build-somebuild-abcd", "somenamespace", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-build-somebuild-stage-a-working-stage-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace")),
+					tb.PipelineTaskInputResource("workspace", "common-workspace"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource")),
 				tb.PipelineTask("another-stage", "somepipeline-build-somebuild-stage-another-stage-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace", tb.From("somepipeline-build-somebuild-stage-a-working-stage-abcd"))),
-				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit))),
+					tb.PipelineTaskInputResource("workspace", "common-workspace",
+						tb.From("somepipeline-build-somebuild-stage-a-working-stage-abcd")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("somepipeline-build-somebuild-stage-a-working-stage-abcd"))),
+				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-a-working-stage-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
-						tb.ResourceTargetPath("workspace"))),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-a-working-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-another-stage-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-another-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("again")),
 				)),
 			},
@@ -185,36 +216,59 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 			},
 			pipeline: tb.Pipeline("somepipeline-build-somebuild-abcd", "somenamespace", tb.PipelineSpec(
 				tb.PipelineTask("first-stage", "somepipeline-build-somebuild-stage-first-stage-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace")),
+					tb.PipelineTaskInputResource("workspace", "common-workspace"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource")),
 				tb.PipelineTask("a-working-stage", "somepipeline-build-somebuild-stage-a-working-stage-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace", tb.From("somepipeline-build-somebuild-stage-first-stage-abcd"))),
+					tb.PipelineTaskInputResource("workspace", "common-workspace",
+						tb.From("somepipeline-build-somebuild-stage-first-stage-abcd")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("somepipeline-build-somebuild-stage-first-stage-abcd"))),
 				tb.PipelineTask("another-stage", "somepipeline-build-somebuild-stage-another-stage-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace", tb.From("somepipeline-build-somebuild-stage-first-stage-abcd"))),
+					tb.PipelineTaskInputResource("workspace", "common-workspace",
+						tb.From("somepipeline-build-somebuild-stage-first-stage-abcd")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("somepipeline-build-somebuild-stage-first-stage-abcd"))),
 				tb.PipelineTask("last-stage", "somepipeline-build-somebuild-stage-last-stage-abcd",
 					// TODO: Switch from this kind of hackish approach to non-resource-based dependencies once they land.
-					tb.PipelineTaskInputResource("workspace", "common-workspace", tb.From("somepipeline-build-somebuild-stage-a-working-stage-abcd",
-						"somepipeline-build-somebuild-stage-another-stage-abcd", "somepipeline-build-somebuild-stage-first-stage-abcd"))),
-				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit))),
+					tb.PipelineTaskInputResource("workspace", "common-workspace",
+						tb.From("somepipeline-build-somebuild-stage-first-stage-abcd")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("somepipeline-build-somebuild-stage-a-working-stage-abcd",
+							"somepipeline-build-somebuild-stage-another-stage-abcd"))),
+				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-first-stage-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
-						tb.ResourceTargetPath("workspace"))),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-first-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("first")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-a-working-stage-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-a-working-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-another-stage-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-another-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("again")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-last-stage-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-last-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("last")),
 				)),
 			},
@@ -276,44 +330,172 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 			},
 			pipeline: tb.Pipeline("somepipeline-build-somebuild-abcd", "somenamespace", tb.PipelineSpec(
 				tb.PipelineTask("first-stage", "somepipeline-build-somebuild-stage-first-stage-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace")),
+					tb.PipelineTaskInputResource("workspace", "common-workspace"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource")),
 				tb.PipelineTask("a-working-stage", "somepipeline-build-somebuild-stage-a-working-stage-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace", tb.From("somepipeline-build-somebuild-stage-first-stage-abcd"))),
+					tb.PipelineTaskInputResource("workspace", "common-workspace",
+						tb.From("somepipeline-build-somebuild-stage-first-stage-abcd")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("somepipeline-build-somebuild-stage-first-stage-abcd"))),
 				tb.PipelineTask("another-stage", "somepipeline-build-somebuild-stage-another-stage-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace", tb.From("somepipeline-build-somebuild-stage-first-stage-abcd"))),
+					tb.PipelineTaskInputResource("workspace", "common-workspace",
+						tb.From("somepipeline-build-somebuild-stage-first-stage-abcd")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("somepipeline-build-somebuild-stage-first-stage-abcd"))),
 				tb.PipelineTask("some-other-stage", "somepipeline-build-somebuild-stage-some-other-stage-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace", tb.From("somepipeline-build-somebuild-stage-another-stage-abcd"))),
+					tb.PipelineTaskInputResource("workspace", "common-workspace",
+						tb.From("somepipeline-build-somebuild-stage-another-stage-abcd")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("somepipeline-build-somebuild-stage-another-stage-abcd"))),
 				tb.PipelineTask("last-stage", "somepipeline-build-somebuild-stage-last-stage-abcd",
 					// TODO: Switch from this kind of hackish approach to non-resource-based dependencies once they land.
-					tb.PipelineTaskInputResource("workspace", "common-workspace", tb.From("somepipeline-build-somebuild-stage-a-working-stage-abcd",
-						"somepipeline-build-somebuild-stage-some-other-stage-abcd", "somepipeline-build-somebuild-stage-first-stage-abcd"))),
-				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit))),
+					tb.PipelineTaskInputResource("workspace", "common-workspace",
+						tb.From("somepipeline-build-somebuild-stage-first-stage-abcd")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("somepipeline-build-somebuild-stage-a-working-stage-abcd",
+							"somepipeline-build-somebuild-stage-some-other-stage-abcd"))),
+				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-first-stage-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
-						tb.ResourceTargetPath("workspace"))),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-first-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("first")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-a-working-stage-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-a-working-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("hello", "world")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-another-stage-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-another-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("again")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-some-other-stage-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-some-other-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("otherwise")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-last-stage-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-last-stage-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("last")),
+				)),
+			},
+		},
+		{
+			name: "custom_workspaces",
+			expected: &Jenkinsfile{
+				APIVersion: "v0.1",
+				Agent: Agent{
+					Image: "some-image",
+				},
+				Stages: []Stage{
+					{
+						Name: "stage1",
+						Steps: []Step{{
+							Command: "ls",
+						}},
+					},
+					{
+						Name: "stage2",
+						Options: StageOptions{
+							Workspace: &customWorkspace,
+						},
+						Steps: []Step{{
+							Command: "ls",
+						}},
+					},
+					{
+						Name: "stage3",
+						Options: StageOptions{
+							Workspace: &defaultWorkspace,
+						},
+						Steps: []Step{{
+							Command: "ls",
+						}},
+					},
+					{
+						Name: "stage4",
+						Options: StageOptions{
+							Workspace: &customWorkspace,
+						},
+						Steps: []Step{{
+							Command: "ls",
+						}},
+					},
+				},
+			},
+			pipeline: tb.Pipeline("somepipeline-build-somebuild-abcd", "somenamespace", tb.PipelineSpec(
+				tb.PipelineTask("stage1", "somepipeline-build-somebuild-stage-stage1-abcd",
+					tb.PipelineTaskInputResource("workspace", "common-workspace"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineTask("stage2", "somepipeline-build-somebuild-stage-stage2-abcd",
+					tb.PipelineTaskInputResource("workspace", "common-workspace"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("somepipeline-build-somebuild-stage-stage1-abcd"))),
+				tb.PipelineTask("stage3", "somepipeline-build-somebuild-stage-stage3-abcd",
+					tb.PipelineTaskInputResource("workspace", "common-workspace",
+						tb.From("somepipeline-build-somebuild-stage-stage1-abcd")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("somepipeline-build-somebuild-stage-stage2-abcd"))),
+				tb.PipelineTask("stage4", "somepipeline-build-somebuild-stage-stage4-abcd",
+					tb.PipelineTaskInputResource("workspace", "common-workspace",
+						tb.From("somepipeline-build-somebuild-stage-stage2-abcd")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("somepipeline-build-somebuild-stage-stage3-abcd"))),
+				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
+			tasks: []*pipelinev1alpha1.Task{
+				tb.Task("somepipeline-build-somebuild-stage-stage1-abcd", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.Step("stage-stage1-step-0-abcd", "some-image", tb.Command("ls")),
+				)),
+				tb.Task("somepipeline-build-somebuild-stage-stage2-abcd", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.Step("stage-stage2-step-0-abcd", "some-image", tb.Command("ls")),
+				)),
+				tb.Task("somepipeline-build-somebuild-stage-stage3-abcd", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.Step("stage-stage3-step-0-abcd", "some-image", tb.Command("ls")),
+				)),
+				tb.Task("somepipeline-build-somebuild-stage-stage4-abcd", "somenamespace", tb.TaskSpec(
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.Step("stage-stage4-step-0-abcd", "some-image", tb.Command("ls")),
 				)),
 			},
 		},
@@ -342,13 +524,18 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 			},
 			pipeline: tb.Pipeline("somepipeline-build-somebuild-abcd", "somenamespace", tb.PipelineSpec(
 				tb.PipelineTask("a-stage-with-environment", "somepipeline-build-somebuild-stage-a-stage-with-environmen-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace")),
-				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit))),
+					tb.PipelineTaskInputResource("workspace", "common-workspace"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-a-stage-with-environmen-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
-						tb.ResourceTargetPath("workspace"))),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-a-stage-with-environment-step-0-abcd", "some-image", tb.Command("echo"), tb.Args("hello", "${SOME_OTHER_VAR}"),
 						// TODO: Ordering doesn't seem to be deterministic.
 						tb.EnvVar("SOME_VAR", "A value for the env var"), tb.EnvVar("SOME_OTHER_VAR", "A value for the other env var")),
@@ -497,13 +684,18 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 			},
 			pipeline: tb.Pipeline("somepipeline-build-somebuild-abcd", "somenamespace", tb.PipelineSpec(
 				tb.PipelineTask("a-working-stage", "somepipeline-build-somebuild-stage-a-working-stage-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace")),
-				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit))),
+					tb.PipelineTaskInputResource("workspace", "common-workspace"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource")),
+				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-a-working-stage-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
-						tb.ResourceTargetPath("workspace"))),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-a-working-stage-step-0-abcd", "some-other-image", tb.Command("echo"), tb.Args("hello", "world")),
 					tb.Step("stage-a-working-stage-step-1-abcd", "some-image", tb.Command("echo"), tb.Args("goodbye")),
 				)),
@@ -535,20 +727,31 @@ func TestParseJenkinsfileYaml(t *testing.T) {
 			},
 			pipeline: tb.Pipeline("somepipeline-build-somebuild-abcd", "somenamespace", tb.PipelineSpec(
 				tb.PipelineTask(".--a--.", "somepipeline-build-somebuild-stage-a-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace")),
+					tb.PipelineTaskInputResource("workspace", "common-workspace"),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource")),
 				tb.PipelineTask("wööh!!!!---this-is-cool.", "somepipeline-build-somebuild-stage-wh-this-is-cool-abcd",
-					tb.PipelineTaskInputResource("workspace", "common-workspace", tb.From("somepipeline-build-somebuild-stage-a-abcd"))),
-				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit))),
+					tb.PipelineTaskInputResource("workspace", "common-workspace",
+						tb.From("somepipeline-build-somebuild-stage-a-abcd")),
+					tb.PipelineTaskInputResource("temp-ordering-resource", "temp-ordering-resource",
+						tb.From("somepipeline-build-somebuild-stage-a-abcd"))),
+				tb.PipelineDeclaredResource("common-workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+				tb.PipelineDeclaredResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit))),
 			tasks: []*pipelinev1alpha1.Task{
 				tb.Task("somepipeline-build-somebuild-stage-a-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
-						tb.ResourceTargetPath("workspace"))),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit,
+							tb.ResourceTargetPath("workspace")),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-a-step-0-abcd", "some-image", tb.Command("ls")),
 				)),
 				tb.Task("somepipeline-build-somebuild-stage-wh-this-is-cool-abcd", "somenamespace", tb.TaskSpec(
-					tb.TaskInputs(tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
-					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskInputs(
+						tb.InputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.InputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
+					tb.TaskOutputs(tb.OutputsResource("workspace", pipelinev1alpha1.PipelineResourceTypeGit),
+						tb.OutputsResource("temp-ordering-resource", pipelinev1alpha1.PipelineResourceTypeGit)),
 					tb.Step("stage-wh-this-is-cool-step-0-abcd", "some-image", tb.Command("ls")),
 				)),
 			},

--- a/pkg/buildpipeline/test_data/custom_workspaces.yaml
+++ b/pkg/buildpipeline/test_data/custom_workspaces.yaml
@@ -1,0 +1,22 @@
+apiVersion: v0.1
+agent:
+  image: some-image
+stages:
+  - name: stage1
+    steps:
+      - command: ls
+  - name: stage2
+    options:
+      workspace: custom
+    steps:
+      - command: ls
+  - name: stage3
+    options:
+      workspace: default
+    steps:
+      - command: ls
+  - name: stage4
+    options:
+      workspace: custom
+    steps:
+      - command: ls

--- a/pkg/buildpipeline/test_data/inherited_custom_workspaces.yaml
+++ b/pkg/buildpipeline/test_data/inherited_custom_workspaces.yaml
@@ -1,0 +1,22 @@
+apiVersion: v0.1
+agent:
+  image: some-image
+stages:
+  - name: stage1
+    steps:
+      - command: ls
+  - name: stage2
+    options:
+      workspace: custom
+    stages:
+      - name: stage3
+        steps:
+          - command: ls
+      - name: stage4
+        options:
+          workspace: default
+        steps:
+          - command: ls
+      - name: stage5
+        steps:
+          - command: ls


### PR DESCRIPTION
Has basic handling for custom workspaces, but could probably use additional tests.

I'm not really sure how the workspace path is supposed to be used, so this doesn't really touch that at all.

All of the passing tests were modified at least slightly because I created another resource named `temp-ordering-resource`, which has all of the ordering relationships for now until we have a better way to do that in Build Pipeline. Uses of `from` for `common-workspace` show which stage is using which workspace and from where.

Main changes for `TransformedStage` were to add two fields that should make graph-related operations easier to handle:
```
// The stage enclosing this stage, or nil if it is at top level
EnclosingStage *TransformedStage
// The stage immediately before this stage at the same depth, or nil if there is no such stage
PreviousSiblingStage *TransformedStage
// TODO: Add the equivalent reverse relationship
```

In ASCII art, this means that we have the ability to traverse upwards from any of the stages in this graph following the given lines:

```
a
|
seq
|||\
||| par
||| |\ \
||| | b c
|| \| 
| \ d
|  \|
|   e
f
```