### PR TITLE
Fix discovery of TaskRun for BuildInfo to be more lenient

### DIFF
--- a/pkg/builds/build_info.go
+++ b/pkg/builds/build_info.go
@@ -56,7 +56,7 @@ func CreateBuildPodInfo(pod *corev1.Pod) *BuildPodInfo {
 	}
 	gitURL := ""
 	for _, initContainer := range pod.Spec.InitContainers {
-		if initContainer.Name == "build-step-git-source" || initContainer.Name == "build-step-git-source-source" {
+		if strings.HasPrefix(initContainer.Name, "build-step-git-source") {
 			args := initContainer.Args
 			for i := 0; i <= len(args)-2; i += 2 {
 				key := args[i]


### PR DESCRIPTION
This gets builds created via `jx step create task` where there's a `jenkins-x.yml` in the directory with `pipelineConfig->pipelines->[release|pullRequest|feature]->pipeline` containing Pipeline YAML syntax to actually show up properly in `jx get build logs`' listing of builds, and in `jx get act`'s list of `PipelineActivity`s. Hoorah!

Specifically here, let's just look for any init container with a name
starting with "build-step-git-source", which covers the Knative Build
approach (that's literally the name there), the current
generated-from-build-packs approach (where it's
"build-step-git-source-source"), and the current
generated-from-Pipeline-YAML approach (where it's "build-step-git-source-workspace").

Obviously we should reconcile the latter two, and rewrite this whole
thing to look to `PipelineRun` rather than pods, but we'll get there later.